### PR TITLE
Adding options and observerElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ You can learn all about this package in our [in-depth blog post](https://beyondc
 
 We spend a lot of time working on our [free developer services](https://beyondco.de/services) or open source packages. You can support our work by [buying one of our paid products](https://beyondco.de/software).
 
+## Development
+
+If you want to create your own build of TailwindCSS JIT CDN, you can fork this repo, clone it, and then run the following commands to get started:
+
+```
+yarn install
+yarn run build
+```
+
+Then, link to your new `dist/tailwindcss-jit-cdn.umd.js` in your project in order to run your build.
+
+## Options
+
+You can define a set of `tailwindOptions` to override a few options for the JIT CDN.
+
+💡 If you have ideas for options you would like to see, let us know. Currently there is only one options available:
+
+```
+window.options = {
+    observerElement: document.getElementById('app')
+};
+```
+
+> In the example above, the TailwindCSS JIT CDN will only observe and modify elements inside of the `app` element. This might be helpful for page speed, user experience, or a few other scenarios.
+
 ## Credits
 
 - [Marcel Pociot](https://github.com/mpociot)

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ Then, link to your new `dist/tailwindcss-jit-cdn.umd.js` in your project in orde
 
 ## Options
 
-You can define a set of `tailwindOptions` to override a few options for the JIT CDN.
-
-💡 If you have ideas for options you would like to see, let us know. Currently there is only one options available:
+A set of `tailwindOptions` to configure for the JIT CDN. Currently there is only one option available, you can use it as follows:
 
 ```
 window.options = {
@@ -42,6 +40,8 @@ window.options = {
 ```
 
 > In the example above, the TailwindCSS JIT CDN will only observe and modify elements inside of the `app` element. This might be helpful for page speed, user experience, or a few other scenarios.
+
+💡 Have ideas for options you would like to see, let us know.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ window.options = {
 };
 ```
 
-> In the example above, the TailwindCSS JIT CDN will only observe and modify elements inside of the `app` element. This might be helpful for page speed, user experience, or a few other scenarios.
+> By default the TailwindCSS JIT CDN will observe your entire page via `document.documentElement`, you can override this option via the `observerElement` property. In the options above the observer will only observe Tailwind classes inside of `app` element. This might be helpful for page speed, user experience, or a few other scenarios.
 
 💡 Have ideas for options you would like to see, let us know.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then, link to your new `dist/tailwindcss-jit-cdn.umd.js` in your project in orde
 A set of `tailwindOptions` to configure for the JIT CDN. Currently there is only one option available, you can use it as follows:
 
 ```
-window.options = {
+window.tailwindOptions = {
     observerElement: document.getElementById('app')
 };
 ```

--- a/src/main.js
+++ b/src/main.js
@@ -1,21 +1,31 @@
 import observerScript from "./observer";
 
-(() => {  
+(() => {
   const config = {
     attributes: true,
     attributeFilter: ["class"],
     childList: true,
-    subtree: true, 
+    subtree: true,
   };
 
-  new MutationObserver(observerScript(false)).observe(
-    document.documentElement,
+  // Set the default options
+  let options = {
+      observerElement: document.documentElement
+  };
+
+  // If the user specified values for window.tailwindOptions, merge those options
+  if(typeof window.tailwindOptions !== 'undefined'){
+      options = { ...options, ...window.tailwindOptions };
+  }
+
+  new MutationObserver(observerScript(options, false)).observe(
+    options.observerElement,
     config
   );
 
   observerScript();
 
   window.tailwindCSS = {
-    refresh: observerScript(true),
+    refresh: observerScript(options, true),
   }
 })();

--- a/src/observer.js
+++ b/src/observer.js
@@ -8,9 +8,9 @@ const tailwindId = nanoid();
 
 let lastProcessedHtml = "";
 
-export default (force = false) => {
+export default (options, force = false) => {
   return async () => {
-    self[VIRTUAL_HTML_FILENAME] = document.documentElement.outerHTML;
+    self[VIRTUAL_HTML_FILENAME] = options.observerElement.outerHTML;
 
     if (self[VIRTUAL_HTML_FILENAME] === lastProcessedHtml && force === false) {
       return;
@@ -25,7 +25,7 @@ export default (force = false) => {
       purge: [VIRTUAL_HTML_FILENAME],
       theme: {},
       plugins: [
-        require("@tailwindcss/forms"), 
+        require("@tailwindcss/forms"),
         require("@tailwindcss/typography"),
         require("@tailwindcss/aspect-ratio"),
         require("@tailwindcss/line-clamp")


### PR DESCRIPTION
Hey Marcel 👋,

I've gone ahead and added an option for oberserverElement.

I added this to the `main.js` file, where it will merge a default options object with `window.tailwindOptions`. This will allow the ability for us to add even more options down the road.

If there is a more efficient way that you feel that I should implement this, let me know.

For now, if you include:

```
window.tailwindOptions = {
    observerElement: document.getElementById('app')
};
```

above the CDN script tag, you can define the element that you want the JIT CDN to observe.

Thanks again for this awesome script ;)